### PR TITLE
Fix: Memory leaks in React root cleanup

### DIFF
--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -80,6 +80,13 @@ export class TasksTimelineSettingTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
+	hide(): void {
+		if (this.root) {
+			this.root.unmount();
+			this.root = undefined;
+		}
+	}
+
 	display(): void {
 		const { containerEl } = this;
 		const container = containerEl;

--- a/src/view.tsx
+++ b/src/view.tsx
@@ -29,7 +29,11 @@ export class TasksTimelineObsidianView extends ItemView {
 
 	protected async onOpen() {
 		const { containerEl } = this;
-		const container = containerEl.children[1]!;
+		const container = containerEl.children[1];
+		if (!container) {
+			console.error("Tasks Timeline: Container element not found");
+			return;
+		}
 		container.empty();
 		this.root = createRoot(container);
 		this.root.render(
@@ -37,6 +41,12 @@ export class TasksTimelineObsidianView extends ItemView {
 				<ObsidianAdaptor plugin={this.plugin} />
 			</React.StrictMode>
 		);
-		return;
+	}
+
+	protected async onClose() {
+		if (this.root) {
+			this.root.unmount();
+			this.root = undefined;
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `onClose()` method to `TasksTimelineObsidianView` to unmount React root when view closes
- Add `hide()` method to `TasksTimelineSettingTab` to unmount React root when settings tab is hidden
- Add null check for container element in view to prevent potential runtime errors

## Test plan
- [ ] Open and close the Tasks Timeline view multiple times
- [ ] Open and close the settings tab multiple times
- [ ] Monitor memory usage in Obsidian developer tools to verify no leaks

Fixes #2, #3, #8

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>