### PR TITLE
Fix: Use stable task IDs based on file path and position

### DIFF
--- a/src/tasksRepo.ts
+++ b/src/tasksRepo.ts
@@ -391,8 +391,10 @@ export class ObsidianTasksRepo implements TaskRepository {
 		}
 
 		tags = [...new Set(tags)];
+		// Create stable ID based on file path and position
+		const stableId = `${filePath}:${position.start.line}:${position.start.col}`;
 		return {
-			id: crypto.randomUUID(),
+			id: stableId,
 			title: description.trim(),
 			status: getTaskStatusFromMarker(statusString),
 			category: filePath,


### PR DESCRIPTION
## Summary
Replace `crypto.randomUUID()` with stable IDs based on file path and position in format: `${filePath}:${line}:${col}`

## Why this matters
- Task IDs were regenerated on every load, breaking task identity
- React couldn't properly reconcile task list changes (forced full re-renders)
- Task update/delete operations could fail after a reload

## Test plan
- [ ] Load tasks and note some task IDs
- [ ] Reload Obsidian and verify the same tasks have the same IDs
- [ ] Update a task and verify the change persists
- [ ] Delete a task and verify it's removed

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>