### PR TITLE
Fix: Correct date format for due field and resolve lint errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export default class TasksTimelineObsidianPlugin extends Plugin {
 				if (mutation.attributeName === "class") {
 					const isDarkMode =
 						document.body.classList.contains("theme-dark");
-					console.log("Theme changed. Dark mode active:", isDarkMode);
+					console.debug("Theme changed. Dark mode active:", isDarkMode);
 					this.settings.systemInDarkMode = isDarkMode;
 					this.bus.emit("system:themeChange", {
 						isDarkMode: isDarkMode,

--- a/src/obsidianAdapter.tsx
+++ b/src/obsidianAdapter.tsx
@@ -127,7 +127,7 @@ export const ObsidianAdaptor = ({ plugin }: ObsidianAdaptorProps) => {
 	const handleTaskAdded = async (task: Task) => {
 		// For now, we don't support adding tasks from the UI
 		// This would require creating a new markdown task in a file
-		console.log("Task added (not implemented):", task);
+		console.debug("Task added (not implemented):", task);
 	};
 
 	const handleTaskUpdated = async (task: Task, previous: Task) => {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -359,8 +359,7 @@ export const parseDataViewFormatItem = (item: Task): Task => {
 		}
 		switch (normalizedKey) {
 			case "due":
-				console.log("got due", fieldDate.toISODate());
-				item.dueAt = fieldDate.toISOTime();
+				item.dueAt = fieldDate.toISODate();
 				break;
 			case "scheduled":
 				item.extra["scheduledAt"] = fieldDate.toISODate();
@@ -368,15 +367,12 @@ export const parseDataViewFormatItem = (item: Task): Task => {
 			case "complete":
 			case "completion":
 			case "done":
-				console.log("got done", fieldDate.toISODate());
 				item.completedAt = fieldDate.toISODate();
 				break;
 			case "created":
-				console.log("got create", fieldDate.toISODate());
 				item.createdAt = fieldDate.toISODate();
 				break;
 			case "start":
-				console.log("got start", fieldDate.toISODate());
 				item.startAt = fieldDate.toISODate();
 				break;
 			default:

--- a/src/view.tsx
+++ b/src/view.tsx
@@ -15,6 +15,7 @@ export class TasksTimelineObsidianView extends ItemView {
 	}
 
 	getDisplayText(): string {
+		// eslint-disable-next-line obsidianmd/ui/sentence-case -- Plugin name
 		return "Tasks Timeline";
 	}
 


### PR DESCRIPTION
## Summary
- Fix bug where 'due' field was formatted as time instead of date in Dataview parser
- Replace `console.log` with `console.debug` to comply with ESLint rules
- Add eslint-disable comment for plugin name in getDisplayText()

## Changes
- `src/parsers.ts`: Change `toISOTime()` to `toISODate()` for due field, remove debug console.log statements
- `src/main.ts`: Change console.log to console.debug for theme change logging
- `src/obsidianAdapter.tsx`: Change console.log to console.debug for task added logging
- `src/view.tsx`: Add eslint-disable for plugin name

## Test plan
- [ ] Create a task with Dataview-style due date `[due:: 2024-01-15]`
- [ ] Verify due date displays correctly in timeline
- [ ] Run `pnpm lint` and verify no errors

Fixes #5, #13

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>