### PR TITLE
feat: support links in task titles

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@tasks-timeline/components':
         specifier: latest
-        version: 0.1.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(prop-types@15.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 0.1.2(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(prop-types@15.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ahooks:
         specifier: ^3.9.6
         version: 3.9.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1382,8 +1382,8 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
-  '@tasks-timeline/components@0.1.1':
-    resolution: {integrity: sha512-SzuUnhosspmc7J7pLuK1DePo5BxUAJeHnq6fUqCFh5gL8x5zFjNpcZTD8PLUPs9CVsxZq2vCHg4ZEsBfQfYMag==}
+  '@tasks-timeline/components@0.1.2':
+    resolution: {integrity: sha512-2WkPPU7zAMXWuvyeOpw9UwEute8tm4uc8MZg76wxrmVu/2+YGEUnmr6MhAvUdbDvrxecWI2UEJJL/coDkkWKtA==}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.30.0'
       openai: '>=4.0.0'
@@ -5164,7 +5164,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@tasks-timeline/components@0.1.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(prop-types@15.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@tasks-timeline/components@0.1.2(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(prop-types@15.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@google/genai': 1.38.0
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/obsidianAdapter.tsx
+++ b/src/obsidianAdapter.tsx
@@ -1,9 +1,10 @@
 import { Task, TasksTimelineApp } from "@tasks-timeline/components";
 import { Events } from "eventbus";
 import TasksTimelineObsidianPlugin from "main";
-import { startTransition, useEffect, useRef, useState } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { ObsidianSettingRepo } from "./settingsRepo";
 import { ObsidianTasksRepo } from "./tasksRepo";
+import { createRenderTitle } from "./titleRenderer";
 import { App, debounce, Notice, Pos, TFile } from "obsidian";
 
 interface ObsidianAdaptorProps {
@@ -68,6 +69,7 @@ export const ObsidianAdaptor = ({ plugin }: ObsidianAdaptorProps) => {
 	// Stable repository instance that holds the cache
 	const stableTasksRepo = useRef(new ObsidianTasksRepo(plugin));
 	const [settingsRepo] = useState(() => new ObsidianSettingRepo(plugin));
+	const renderTitle = useMemo(() => createRenderTitle(plugin.app), [plugin]);
 
 	// Load tasks on mount and when refreshToken changes
 	const loadTasks = async () => {
@@ -177,6 +179,7 @@ export const ObsidianAdaptor = ({ plugin }: ObsidianAdaptorProps) => {
 			settingsRepository={settingsRepo}
 			systemInDarkMode={isDarkMode}
 			onItemClick={(item) => handleItemClick(item, plugin.app)}
+			renderTitle={renderTitle}
 		/>
 	);
 };

--- a/src/titleRenderer.tsx
+++ b/src/titleRenderer.tsx
@@ -1,0 +1,159 @@
+import { App } from "obsidian";
+import React from "react";
+
+type TitleSegment =
+	| { type: "text"; content: string }
+	| { type: "markdown-link"; text: string; url: string }
+	| { type: "wikilink"; page: string; display?: string }
+	| { type: "bare-url"; url: string };
+
+const linkBaseStyle: React.CSSProperties = {
+	cursor: "pointer",
+	textDecoration: "underline",
+	textUnderlineOffset: "2px",
+};
+
+const externalLinkStyle: React.CSSProperties = {
+	...linkBaseStyle,
+	color: "var(--link-external-color, #705dcf)",
+};
+
+const internalLinkStyle: React.CSSProperties = {
+	...linkBaseStyle,
+	color: "var(--link-color, #7f6df2)",
+	textDecoration: "none",
+};
+
+/**
+ * Combined regex matching link types in priority order (left-to-right):
+ * 1. Markdown links: [text](url)
+ * 2. Wikilinks: [[page]] or [[page|display]]
+ * 3. Bare URLs: https://... or http://...
+ *
+ * Group mapping:
+ *   [1] = markdown link text
+ *   [2] = markdown link url
+ *   [3] = wikilink page
+ *   [4] = wikilink display (optional)
+ *   [5] = bare url
+ */
+const LINK_REGEX =
+	/\[([^\]]*)\]\(([^)]+)\)|\[\[([^\]|]+)(?:\|([^\]]+))?\]\]|(https?:\/\/[^\s<>[\]]+)/g;
+
+export function parseTitleSegments(title: string): TitleSegment[] {
+	const segments: TitleSegment[] = [];
+	let lastIndex = 0;
+
+	const regex = new RegExp(LINK_REGEX.source, "g");
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(title)) !== null) {
+		if (match.index > lastIndex) {
+			segments.push({
+				type: "text",
+				content: title.slice(lastIndex, match.index),
+			});
+		}
+
+		if (match[1] !== undefined && match[2] !== undefined) {
+			segments.push({
+				type: "markdown-link",
+				text: match[1],
+				url: match[2],
+			});
+		} else if (match[3] !== undefined) {
+			segments.push({
+				type: "wikilink",
+				page: match[3],
+				display: match[4],
+			});
+		} else if (match[5] !== undefined) {
+			segments.push({ type: "bare-url", url: match[5] });
+		}
+
+		lastIndex = match.index + match[0].length;
+	}
+
+	if (lastIndex < title.length) {
+		segments.push({ type: "text", content: title.slice(lastIndex) });
+	}
+
+	return segments;
+}
+
+export function createRenderTitle(
+	app: App
+): (title: string) => React.ReactNode {
+	const handleExternalLink = (e: React.MouseEvent, url: string) => {
+		e.preventDefault();
+		e.stopPropagation();
+		window.open(url, "_blank");
+	};
+
+	const handleInternalLink = (e: React.MouseEvent, page: string) => {
+		e.preventDefault();
+		e.stopPropagation();
+		void app.workspace.openLinkText(page, "", "tab");
+	};
+
+	return (title: string): React.ReactNode => {
+		const segments = parseTitleSegments(title);
+
+		if (segments.length === 1 && segments[0].type === "text") {
+			return title;
+		}
+
+		return segments.map(
+			(seg: TitleSegment, i: number): React.ReactNode => {
+				switch (seg.type) {
+					case "text":
+						return (
+							<span key={i}>{seg.content}</span>
+						);
+					case "markdown-link":
+						return (
+							<a
+								key={i}
+								style={externalLinkStyle}
+								href={seg.url}
+								onClick={(e) =>
+									handleExternalLink(e, seg.url)
+								}
+								aria-label={`Open ${seg.text} in browser`}
+							>
+								{seg.text}
+							</a>
+						);
+					case "wikilink":
+						return (
+							<a
+								key={i}
+								style={internalLinkStyle}
+								data-href={seg.page}
+								onClick={(e) =>
+									handleInternalLink(e, seg.page)
+								}
+								aria-label={`Open ${seg.display ?? seg.page} in new tab`}
+							>
+								{seg.display ?? seg.page}
+							</a>
+						);
+					case "bare-url":
+						return (
+							<a
+								key={i}
+								style={externalLinkStyle}
+								href={seg.url}
+								onClick={(e) =>
+									handleExternalLink(e, seg.url)
+								}
+								aria-label={`Open ${seg.url} in browser`}
+							>
+								{seg.url}
+							</a>
+						);
+				}
+			}
+		);
+	};
+}


### PR DESCRIPTION
## Summary

- Add `titleRenderer.tsx` with a link parser (`parseTitleSegments`) and React renderer (`createRenderTitle`) that handles markdown links `[text](url)`, Obsidian wikilinks `[[page]]`/`[[page|display]]`, and bare URLs
- Wire the `renderTitle` callback into `ObsidianAdaptor` via the new prop from `@tasks-timeline/components` v0.1.2
- External links open in the default browser; internal wikilinks open in a new Obsidian tab
- Uses inline styles (with CSS variable fallbacks) to work inside the component library's Shadow DOM

Closes #22
Depends on Leonezz/tasks-timeline-components#23

## Test plan

- [ ] Task with markdown link `[text](https://example.com)` renders as clickable styled link
- [ ] Task with wikilink `[[Some Note]]` renders as clickable internal link, opens in new tab
- [ ] Task with wikilink alias `[[Some Note|Display]]` shows display text
- [ ] Task with bare URL `https://example.com` renders as clickable link
- [ ] Task with mixed links and plain text renders correctly
- [ ] Clicking a link does NOT also trigger the task item click handler
- [ ] Task titles without any links render as before (plain text, no extra spans)
- [ ] Editing a task with links preserves the raw markdown in the vault file