### PR TITLE
feat: update settings data model to v0.1.2 and integrate SecretStorage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,14 @@
 import { Plugin } from "obsidian";
 import {
+	CURRENT_SETTINGS_VERSION,
 	DEFAULT_SETTINGS,
 	TasksTimelinePluginSettings as TasksTimelineObsidianPluginSettings,
 	TasksTimelineSettingTab,
 } from "./settings";
 import { TasksTimelineObsidianView, VIEW_TYPE } from "./view";
 import { Events, TypedBus } from "./eventbus";
+import { migrateSettings } from "./settingsMigration";
+import { migrateExistingKeysToSecretStorage } from "./secretStorage";
 
 export default class TasksTimelineObsidianPlugin extends Plugin {
 	settings: TasksTimelineObsidianPluginSettings;
@@ -53,11 +56,34 @@ export default class TasksTimelineObsidianPlugin extends Plugin {
 	}
 
 	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			(await this.loadData()) as Partial<TasksTimelineObsidianPluginSettings>
+		const raw = (await this.loadData()) as
+			| Partial<TasksTimelineObsidianPluginSettings>
+			| undefined;
+
+		const appSetting = migrateSettings(
+			raw?.appSetting,
+			DEFAULT_SETTINGS.appSetting
 		);
+
+		this.settings = {
+			systemInDarkMode:
+				raw?.systemInDarkMode ?? DEFAULT_SETTINGS.systemInDarkMode,
+			appSetting,
+			_settingsVersion: raw?._settingsVersion,
+		};
+
+		// One-time migration: move plaintext keys to SecretStorage
+		if (
+			this.settings._settingsVersion === undefined ||
+			this.settings._settingsVersion < CURRENT_SETTINGS_VERSION
+		) {
+			this.settings.appSetting = migrateExistingKeysToSecretStorage(
+				this.app,
+				this.settings.appSetting
+			);
+			this.settings._settingsVersion = CURRENT_SETTINGS_VERSION;
+			await this.saveSettings();
+		}
 	}
 
 	async saveSettings() {

--- a/src/secretStorage.ts
+++ b/src/secretStorage.ts
@@ -1,0 +1,150 @@
+import type { AIProvider, AppSettings, VoiceProvider } from "@tasks-timeline/components";
+import type { App } from "obsidian";
+
+/**
+ * Feature detection: returns true if Obsidian supports SecretStorage (>= 1.11.4).
+ */
+export function hasSecretStorage(app: App): boolean {
+	return (
+		"secretStorage" in app &&
+		app.secretStorage != null &&
+		typeof app.secretStorage.getSecret === "function"
+	);
+}
+
+function aiSecretId(provider: AIProvider): string {
+	return `tasks-timeline-ai-${provider}-apikey`;
+}
+
+function voiceSecretId(provider: VoiceProvider): string {
+	return `tasks-timeline-voice-${provider}-apikey`;
+}
+
+/**
+ * Reads API keys from SecretStorage and populates them into the settings object.
+ * Returns a new settings object with keys filled in.
+ * If SecretStorage is unavailable, returns settings as-is.
+ */
+export function resolveSecrets(app: App, settings: AppSettings): AppSettings {
+	if (!hasSecretStorage(app)) {
+		return settings;
+	}
+
+	const ss = app.secretStorage;
+	let result = { ...settings };
+
+	// Resolve AI provider keys
+	if (result.aiConfig?.providers) {
+		const updatedProviders = { ...result.aiConfig.providers };
+		for (const provider of Object.keys(updatedProviders) as AIProvider[]) {
+			const secret = ss.getSecret(aiSecretId(provider));
+			if (secret) {
+				updatedProviders[provider] = {
+					...updatedProviders[provider],
+					apiKey: secret,
+				};
+			}
+		}
+		result = {
+			...result,
+			aiConfig: { ...result.aiConfig, providers: updatedProviders },
+		};
+	}
+
+	// Resolve voice provider keys
+	if (result.voiceConfig?.providers) {
+		const voiceProviders = { ...result.voiceConfig.providers };
+		const openaiVoiceSecret = ss.getSecret(voiceSecretId("openai"));
+		if (openaiVoiceSecret) {
+			voiceProviders.openai = {
+				...voiceProviders.openai,
+				apiKey: openaiVoiceSecret,
+			};
+		}
+		const geminiVoiceSecret = ss.getSecret(voiceSecretId("gemini"));
+		if (geminiVoiceSecret) {
+			voiceProviders.gemini = {
+				...voiceProviders.gemini,
+				apiKey: geminiVoiceSecret,
+			};
+		}
+		result = {
+			...result,
+			voiceConfig: { ...result.voiceConfig, providers: voiceProviders },
+		};
+	}
+
+	return result;
+}
+
+/**
+ * Extracts non-empty API keys from settings, stores them in SecretStorage,
+ * and returns settings with those keys cleared to "".
+ * If SecretStorage is unavailable, returns settings as-is.
+ */
+export function extractAndStoreSecrets(
+	app: App,
+	settings: AppSettings
+): AppSettings {
+	if (!hasSecretStorage(app)) {
+		return settings;
+	}
+
+	const ss = app.secretStorage;
+	let result = { ...settings };
+
+	// Extract AI provider keys
+	if (result.aiConfig?.providers) {
+		const updatedProviders = { ...result.aiConfig.providers };
+		for (const provider of Object.keys(updatedProviders) as AIProvider[]) {
+			const key = updatedProviders[provider]?.apiKey;
+			if (key) {
+				ss.setSecret(aiSecretId(provider), key);
+				updatedProviders[provider] = {
+					...updatedProviders[provider],
+					apiKey: "",
+				};
+			}
+		}
+		result = {
+			...result,
+			aiConfig: { ...result.aiConfig, providers: updatedProviders },
+		};
+	}
+
+	// Extract voice provider keys
+	if (result.voiceConfig?.providers) {
+		const voiceProviders = { ...result.voiceConfig.providers };
+		if (voiceProviders.openai?.apiKey) {
+			ss.setSecret(voiceSecretId("openai"), voiceProviders.openai.apiKey);
+			voiceProviders.openai = {
+				...voiceProviders.openai,
+				apiKey: "",
+			};
+		}
+		if (voiceProviders.gemini?.apiKey) {
+			ss.setSecret(voiceSecretId("gemini"), voiceProviders.gemini.apiKey);
+			voiceProviders.gemini = {
+				...voiceProviders.gemini,
+				apiKey: "",
+			};
+		}
+		result = {
+			...result,
+			voiceConfig: { ...result.voiceConfig, providers: voiceProviders },
+		};
+	}
+
+	return result;
+}
+
+/**
+ * One-time migration: if plaintext API keys exist in settings, move them to SecretStorage.
+ * Returns settings with keys cleared.
+ */
+export function migrateExistingKeysToSecretStorage(
+	app: App,
+	settings: AppSettings
+): AppSettings {
+	return extractAndStoreSecrets(app, settings);
+}

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -11,11 +11,15 @@ import {
 	SortState,
 } from "@tasks-timeline/components";
 import { unmountReactRoot } from "./view";
+import { extractAndStoreSecrets } from "./secretStorage";
 
 export interface TasksTimelinePluginSettings {
 	appSetting: AppSettings;
 	systemInDarkMode: boolean;
+	_settingsVersion?: number;
 }
+
+export const CURRENT_SETTINGS_VERSION = 2;
 
 export const DEFAULT_SETTINGS: TasksTimelinePluginSettings = {
 	appSetting: {
@@ -47,11 +51,30 @@ export const DEFAULT_SETTINGS: TasksTimelinePluginSettings = {
 					baseUrl: "",
 					model: "",
 				},
+				"openai-compatible": {
+					apiKey: "",
+					baseUrl: "",
+					model: "",
+				},
 			},
 		},
-
-		enableVoiceInput: true,
-		voiceProvider: "browser",
+		voiceConfig: {
+			enabled: true,
+			activeProvider: "browser",
+			language: "en-US",
+			providers: {
+				browser: {},
+				openai: {
+					apiKey: "",
+					baseUrl: "",
+					model: "",
+				},
+				gemini: {
+					apiKey: "",
+					model: "",
+				},
+			},
+		},
 		defaultFocusMode: true,
 		totalTokenUsage: 0,
 		defaultCategory: "",
@@ -70,6 +93,7 @@ export const DEFAULT_SETTINGS: TasksTimelinePluginSettings = {
 		},
 	},
 	systemInDarkMode: false,
+	_settingsVersion: CURRENT_SETTINGS_VERSION,
 };
 
 export class TasksTimelineSettingTab extends PluginSettingTab {
@@ -95,7 +119,8 @@ export class TasksTimelineSettingTab extends PluginSettingTab {
 			onClose: () => {},
 			settings: this.plugin.settings.appSetting,
 			onUpdateSettings: (s: AppSettings) => {
-				this.plugin.settings.appSetting = s;
+				const cleaned = extractAndStoreSecrets(this.app, s);
+				this.plugin.settings.appSetting = cleaned;
 				void this.plugin.saveSettings();
 			},
 			filters: {

--- a/src/settingsMigration.ts
+++ b/src/settingsMigration.ts
@@ -1,0 +1,134 @@
+import type { AIProvider, AppSettings } from "@tasks-timeline/components";
+
+/**
+ * Checks if a value is a plain object (not null, not array, not Date, etc.)
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	);
+}
+
+/**
+ * Recursively deep-merges `saved` into `defaults`.
+ * - Plain objects are merged recursively (saved values override defaults, missing keys filled from defaults)
+ * - Arrays and primitives from `saved` override `defaults` entirely
+ * - Keys present in `saved` but not in `defaults` are preserved
+ */
+export function deepMergeSettings<T>(defaults: T, saved: Partial<T>): T {
+	if (!isPlainObject(defaults) || !isPlainObject(saved)) {
+		return (saved ?? defaults) as T;
+	}
+
+	const result: Record<string, unknown> = {};
+
+	// Start with all keys from defaults
+	for (const key of Object.keys(defaults)) {
+		const defaultVal: unknown = (defaults as Record<string, unknown>)[key];
+		const savedVal: unknown = (saved as Record<string, unknown>)[key];
+
+		if (savedVal === undefined) {
+			result[key] = defaultVal;
+		} else if (isPlainObject(defaultVal) && isPlainObject(savedVal)) {
+			result[key] = deepMergeSettings(defaultVal, savedVal);
+		} else {
+			result[key] = savedVal;
+		}
+	}
+
+	// Preserve keys that exist in saved but not in defaults
+	for (const key of Object.keys(saved)) {
+		if (!(key in defaults)) {
+			result[key] = (saved as Record<string, unknown>)[key];
+		}
+	}
+
+	return result as T;
+}
+
+/**
+ * Shape of v1 settings that had flat voice fields instead of voiceConfig.
+ */
+interface V1AppSettings {
+	enableVoiceInput?: boolean;
+	voiceProvider?: string;
+}
+
+/**
+ * Migrates v1 flat voice fields to the v2 voiceConfig structure.
+ * Also ensures the "openai-compatible" AI provider exists.
+ * Removes stale flat fields after migration.
+ */
+export function migrateV1ToV2(appSetting: AppSettings): AppSettings {
+	const raw = appSetting as AppSettings & V1AppSettings;
+	let result = { ...raw };
+
+	// Migrate flat voice fields → voiceConfig
+	if (
+		("enableVoiceInput" in raw || "voiceProvider" in raw) &&
+		!("voiceConfig" in raw && raw.voiceConfig)
+	) {
+		result = {
+			...result,
+			voiceConfig: {
+				enabled: raw.enableVoiceInput ?? true,
+				activeProvider:
+					(raw.voiceProvider as "browser" | "openai" | "gemini") ??
+					"browser",
+				language: "en-US",
+				providers: {
+					browser: {},
+					openai: { apiKey: "", baseUrl: "", model: "" },
+					gemini: { apiKey: "", model: "" },
+				},
+			},
+		};
+	}
+
+	// Remove stale flat fields
+	const cleaned = result as Record<string, unknown>;
+	delete cleaned["enableVoiceInput"];
+	delete cleaned["voiceProvider"];
+
+	// Ensure "openai-compatible" provider exists in aiConfig
+	if (result.aiConfig?.providers) {
+		const compatKey: AIProvider = "openai-compatible";
+		if (!(compatKey in result.aiConfig.providers)) {
+			const updatedProviders = Object.assign(
+				{},
+				result.aiConfig.providers,
+				{ [compatKey]: { apiKey: "", baseUrl: "", model: "" } }
+			) as AppSettings["aiConfig"]["providers"];
+			result = {
+				...result,
+				aiConfig: {
+					...result.aiConfig,
+					providers: updatedProviders,
+				},
+			};
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Orchestrates settings migration: run shape migrations first (so flat fields
+ * get converted to their structured equivalents), then deep-merge with defaults
+ * to fill any missing keys. Idempotent — safe to call on already-migrated settings.
+ */
+export function migrateSettings(
+	raw: Partial<AppSettings> | undefined,
+	defaults: AppSettings
+): AppSettings {
+	if (!raw) {
+		return { ...defaults };
+	}
+
+	// Migrate shape first so flat fields become structured before merging
+	const migrated = migrateV1ToV2(raw as AppSettings);
+	return deepMergeSettings(defaults, migrated as Partial<AppSettings>);
+}

--- a/src/settingsRepo.ts
+++ b/src/settingsRepo.ts
@@ -1,5 +1,6 @@
 import { AppSettings, SettingsRepository } from "@tasks-timeline/components";
 import TasksTimelineObsidianPlugin from "main";
+import { resolveSecrets, extractAndStoreSecrets } from "./secretStorage";
 
 export class ObsidianSettingRepo implements SettingsRepository {
 	private plugin: TasksTimelineObsidianPlugin;
@@ -12,7 +13,11 @@ export class ObsidianSettingRepo implements SettingsRepository {
 			this.plugin
 				.loadSettings()
 				.then(() => {
-					rsv(this.plugin.settings.appSetting);
+					const settings = resolveSecrets(
+						this.plugin.app,
+						this.plugin.settings.appSetting
+					);
+					rsv(settings);
 				})
 				.catch((e) => {
 					if (e instanceof Error) rej(e);
@@ -21,7 +26,8 @@ export class ObsidianSettingRepo implements SettingsRepository {
 		});
 	}
 	saveSettings(settings: AppSettings): Promise<void> {
-		this.plugin.settings.appSetting = settings;
+		const cleaned = extractAndStoreSecrets(this.plugin.app, settings);
+		this.plugin.settings.appSetting = cleaned;
 		return this.plugin.saveSettings();
 	}
 }

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -217,15 +217,33 @@ export interface PluginManifest {
 	isDesktopOnly: boolean;
 }
 
+export class SecretStorage {
+	private secrets = new Map<string, string>();
+
+	setSecret(id: string, secret: string): void {
+		this.secrets.set(id, secret);
+	}
+
+	getSecret(id: string): string | null {
+		return this.secrets.get(id) ?? null;
+	}
+
+	listSecrets(): string[] {
+		return Array.from(this.secrets.keys());
+	}
+}
+
 export class App {
 	vault: Vault;
 	metadataCache: MetadataCache;
 	workspace: Workspace;
+	secretStorage: SecretStorage;
 
 	constructor() {
 		this.vault = new Vault();
 		this.metadataCache = new MetadataCache();
 		this.workspace = new Workspace();
+		this.secretStorage = new SecretStorage();
 	}
 }
 

--- a/tests/unit/secretStorage.test.ts
+++ b/tests/unit/secretStorage.test.ts
@@ -1,0 +1,196 @@
+import type { AppSettings } from "@tasks-timeline/components";
+import { App } from "../mocks/obsidian";
+import {
+	hasSecretStorage,
+	resolveSecrets,
+	extractAndStoreSecrets,
+	migrateExistingKeysToSecretStorage,
+} from "../../src/secretStorage";
+
+const defaultAppSetting: AppSettings = {
+	theme: "system",
+	dateFormat: "MM, DD",
+	showCompleted: true,
+	showProgressBar: true,
+	soundEnabled: true,
+	fontSize: "base",
+	useRelativeDates: true,
+	groupingStrategy: ["dueAt"],
+	aiConfig: {
+		enabled: true,
+		defaultMode: true,
+		activeProvider: "gemini",
+		providers: {
+			gemini: { apiKey: "", baseUrl: "", model: "" },
+			anthropic: { apiKey: "", baseUrl: "", model: "" },
+			openai: { apiKey: "", baseUrl: "", model: "" },
+			"openai-compatible": { apiKey: "", baseUrl: "", model: "" },
+		},
+	},
+	voiceConfig: {
+		enabled: true,
+		activeProvider: "browser",
+		language: "en-US",
+		providers: {
+			browser: {},
+			openai: { apiKey: "", baseUrl: "", model: "" },
+			gemini: { apiKey: "", model: "" },
+		},
+	},
+	defaultFocusMode: true,
+	totalTokenUsage: 0,
+	defaultCategory: "",
+	filters: {
+		tags: [],
+		categories: [],
+		priorities: [],
+		statuses: [],
+		enableScript: false,
+		script: "",
+	},
+	sort: {
+		script: "",
+		direction: "asc",
+		field: "createdAt",
+	},
+};
+
+function makeApp(): App {
+	return new App();
+}
+
+function makeSettingsWithKeys(): AppSettings {
+	return {
+		...defaultAppSetting,
+		aiConfig: {
+			...defaultAppSetting.aiConfig,
+			providers: {
+				gemini: { apiKey: "gemini-secret", baseUrl: "", model: "" },
+				anthropic: { apiKey: "anthropic-secret", baseUrl: "", model: "" },
+				openai: { apiKey: "", baseUrl: "", model: "" },
+				"openai-compatible": {
+					apiKey: "compat-secret",
+					baseUrl: "https://custom.api",
+					model: "gpt-4",
+				},
+			},
+		},
+		voiceConfig: {
+			...defaultAppSetting.voiceConfig,
+			providers: {
+				browser: {},
+				openai: {
+					apiKey: "voice-openai-key",
+					baseUrl: "https://voice.api",
+					model: "whisper-1",
+				},
+				gemini: { apiKey: "voice-gemini-key", model: "gemini-voice" },
+			},
+		},
+	};
+}
+
+describe("hasSecretStorage", () => {
+	it("returns true when secretStorage exists with methods", () => {
+		const app = makeApp();
+		expect(hasSecretStorage(app as never)).toBe(true);
+	});
+
+	it("returns false when secretStorage is missing", () => {
+		const app = makeApp();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+		delete (app as any).secretStorage;
+		expect(hasSecretStorage(app as never)).toBe(false);
+	});
+});
+
+describe("extractAndStoreSecrets + resolveSecrets round-trip", () => {
+	it("extracts keys to SecretStorage and resolves them back", () => {
+		const app = makeApp();
+		const settings = makeSettingsWithKeys();
+
+		const cleaned = extractAndStoreSecrets(app as never, settings);
+		expect(cleaned.aiConfig.providers.gemini.apiKey).toBe("");
+		expect(cleaned.aiConfig.providers.anthropic.apiKey).toBe("");
+		expect(cleaned.aiConfig.providers["openai-compatible"].apiKey).toBe("");
+		expect(cleaned.voiceConfig.providers.openai.apiKey).toBe("");
+		expect(cleaned.voiceConfig.providers.gemini.apiKey).toBe("");
+		expect(cleaned.aiConfig.providers.openai.apiKey).toBe("");
+
+		// Non-key fields preserved
+		expect(
+			cleaned.aiConfig.providers["openai-compatible"].baseUrl
+		).toBe("https://custom.api");
+
+		const resolved = resolveSecrets(app as never, cleaned);
+		expect(resolved.aiConfig.providers.gemini.apiKey).toBe("gemini-secret");
+		expect(resolved.aiConfig.providers.anthropic.apiKey).toBe(
+			"anthropic-secret"
+		);
+		expect(resolved.aiConfig.providers["openai-compatible"].apiKey).toBe(
+			"compat-secret"
+		);
+		expect(resolved.voiceConfig.providers.openai.apiKey).toBe(
+			"voice-openai-key"
+		);
+		expect(resolved.voiceConfig.providers.gemini.apiKey).toBe(
+			"voice-gemini-key"
+		);
+		expect(resolved.aiConfig.providers.openai.apiKey).toBe("");
+	});
+
+	it("handles partial keys (only some providers have keys)", () => {
+		const app = makeApp();
+		const settings: AppSettings = {
+			...defaultAppSetting,
+			aiConfig: {
+				...defaultAppSetting.aiConfig,
+				providers: {
+					gemini: { apiKey: "only-gemini", baseUrl: "", model: "" },
+					anthropic: { apiKey: "", baseUrl: "", model: "" },
+					openai: { apiKey: "", baseUrl: "", model: "" },
+					"openai-compatible": { apiKey: "", baseUrl: "", model: "" },
+				},
+			},
+		};
+
+		const cleaned = extractAndStoreSecrets(app as never, settings);
+		expect(cleaned.aiConfig.providers.gemini.apiKey).toBe("");
+
+		const resolved = resolveSecrets(app as never, cleaned);
+		expect(resolved.aiConfig.providers.gemini.apiKey).toBe("only-gemini");
+		expect(resolved.aiConfig.providers.anthropic.apiKey).toBe("");
+	});
+});
+
+describe("no SecretStorage fallback", () => {
+	it("returns settings unchanged when SecretStorage is missing", () => {
+		const app = makeApp();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+		delete (app as any).secretStorage;
+		const settings = makeSettingsWithKeys();
+
+		const cleaned = extractAndStoreSecrets(app as never, settings);
+		expect(cleaned.aiConfig.providers.gemini.apiKey).toBe("gemini-secret");
+
+		const resolved = resolveSecrets(app as never, settings);
+		expect(resolved.aiConfig.providers.gemini.apiKey).toBe("gemini-secret");
+	});
+});
+
+describe("migrateExistingKeysToSecretStorage", () => {
+	it("is equivalent to extractAndStoreSecrets", () => {
+		const app = makeApp();
+		const settings = makeSettingsWithKeys();
+
+		const result = migrateExistingKeysToSecretStorage(
+			app as never,
+			settings
+		);
+		expect(result.aiConfig.providers.gemini.apiKey).toBe("");
+
+		expect(app.secretStorage.getSecret("tasks-timeline-ai-gemini-apikey")).toBe(
+			"gemini-secret"
+		);
+	});
+});

--- a/tests/unit/settingsMigration.test.ts
+++ b/tests/unit/settingsMigration.test.ts
@@ -1,0 +1,215 @@
+import type { AppSettings } from "@tasks-timeline/components";
+import {
+	deepMergeSettings,
+	migrateV1ToV2,
+	migrateSettings,
+} from "../../src/settingsMigration";
+
+const defaultAppSetting: AppSettings = {
+	theme: "system",
+	dateFormat: "MM, DD",
+	showCompleted: true,
+	showProgressBar: true,
+	soundEnabled: true,
+	fontSize: "base",
+	useRelativeDates: true,
+	groupingStrategy: ["dueAt"],
+	aiConfig: {
+		enabled: true,
+		defaultMode: true,
+		activeProvider: "gemini",
+		providers: {
+			gemini: { apiKey: "", baseUrl: "", model: "" },
+			anthropic: { apiKey: "", baseUrl: "", model: "" },
+			openai: { apiKey: "", baseUrl: "", model: "" },
+			"openai-compatible": { apiKey: "", baseUrl: "", model: "" },
+		},
+	},
+	voiceConfig: {
+		enabled: true,
+		activeProvider: "browser",
+		language: "en-US",
+		providers: {
+			browser: {},
+			openai: { apiKey: "", baseUrl: "", model: "" },
+			gemini: { apiKey: "", model: "" },
+		},
+	},
+	defaultFocusMode: true,
+	totalTokenUsage: 0,
+	defaultCategory: "",
+	filters: {
+		tags: [],
+		categories: [],
+		priorities: [],
+		statuses: [],
+		enableScript: false,
+		script: "",
+	},
+	sort: {
+		script: "",
+		direction: "asc",
+		field: "createdAt",
+	},
+};
+
+describe("deepMergeSettings", () => {
+	it("returns defaults when saved is empty", () => {
+		const result = deepMergeSettings(defaultAppSetting, {});
+		expect(result).toEqual(defaultAppSetting);
+	});
+
+	it("overrides top-level primitives from saved", () => {
+		const result = deepMergeSettings(defaultAppSetting, {
+			theme: "dark",
+			fontSize: "lg",
+		});
+		expect(result.theme).toBe("dark");
+		expect(result.fontSize).toBe("lg");
+		expect(result.showCompleted).toBe(true);
+	});
+
+	it("deep-merges nested objects", () => {
+		const result = deepMergeSettings(defaultAppSetting, {
+			aiConfig: {
+				enabled: false,
+				defaultMode: true,
+				activeProvider: "openai",
+				providers: {
+					gemini: { apiKey: "my-key", baseUrl: "", model: "" },
+					anthropic: { apiKey: "", baseUrl: "", model: "" },
+					openai: { apiKey: "", baseUrl: "", model: "" },
+					"openai-compatible": { apiKey: "", baseUrl: "", model: "" },
+				},
+			},
+		});
+		expect(result.aiConfig.enabled).toBe(false);
+		expect(result.aiConfig.activeProvider).toBe("openai");
+		expect(result.aiConfig.providers.gemini.apiKey).toBe("my-key");
+		expect(result.voiceConfig).toEqual(defaultAppSetting.voiceConfig);
+	});
+
+	it("preserves saved keys not present in defaults", () => {
+		const result = deepMergeSettings(
+			{ a: 1 } as unknown as AppSettings,
+			{ a: 2, b: 3 } as unknown as Partial<AppSettings>
+		);
+		expect((result as unknown as Record<string, number>)["b"]).toBe(3);
+	});
+
+	it("handles arrays by replacing entirely", () => {
+		const result = deepMergeSettings(defaultAppSetting, {
+			groupingStrategy: ["createdAt"],
+		});
+		expect(result.groupingStrategy).toEqual(["createdAt"]);
+	});
+});
+
+describe("migrateV1ToV2", () => {
+	it("converts flat voice fields to voiceConfig", () => {
+		const v1Settings = {
+			...defaultAppSetting,
+			voiceConfig: undefined,
+		} as unknown as AppSettings;
+		const raw = v1Settings as AppSettings & {
+			enableVoiceInput: boolean;
+			voiceProvider: string;
+		};
+		raw.enableVoiceInput = false;
+		raw.voiceProvider = "openai";
+
+		const result = migrateV1ToV2(raw);
+
+		expect(result.voiceConfig).toBeDefined();
+		expect(result.voiceConfig.enabled).toBe(false);
+		expect(result.voiceConfig.activeProvider).toBe("openai");
+		expect("enableVoiceInput" in result).toBe(false);
+		expect("voiceProvider" in result).toBe(false);
+	});
+
+	it("does not overwrite existing voiceConfig", () => {
+		const settings = { ...defaultAppSetting };
+		const result = migrateV1ToV2(settings);
+		expect(result.voiceConfig).toEqual(defaultAppSetting.voiceConfig);
+	});
+
+	it("adds openai-compatible provider if missing", () => {
+		const settings = { ...defaultAppSetting };
+		const providers = { ...settings.aiConfig.providers } as Record<
+			string,
+			unknown
+		>;
+		delete providers["openai-compatible"];
+		const withoutCompat = {
+			...settings,
+			aiConfig: {
+				...settings.aiConfig,
+				providers: providers as AppSettings["aiConfig"]["providers"],
+			},
+		};
+
+		const result = migrateV1ToV2(withoutCompat);
+		expect(result.aiConfig.providers["openai-compatible"]).toEqual({
+			apiKey: "",
+			baseUrl: "",
+			model: "",
+		});
+	});
+
+	it("is idempotent on already-migrated settings", () => {
+		const first = migrateV1ToV2(defaultAppSetting);
+		const second = migrateV1ToV2(first);
+		expect(second).toEqual(first);
+	});
+});
+
+describe("migrateSettings", () => {
+	it("returns defaults for undefined raw", () => {
+		const result = migrateSettings(undefined, defaultAppSetting);
+		expect(result.voiceConfig).toEqual(defaultAppSetting.voiceConfig);
+		expect(result.aiConfig.providers["openai-compatible"]).toBeDefined();
+	});
+
+	it("deep-merges and migrates v1 data", () => {
+		const v1Raw = {
+			theme: "dark" as const,
+			aiConfig: {
+				enabled: true,
+				defaultMode: true,
+				activeProvider: "gemini" as const,
+				providers: {
+					gemini: { apiKey: "test-key", baseUrl: "", model: "" },
+					anthropic: { apiKey: "", baseUrl: "", model: "" },
+					openai: { apiKey: "", baseUrl: "", model: "" },
+				},
+			},
+			enableVoiceInput: false,
+			voiceProvider: "openai",
+		};
+
+		const result = migrateSettings(
+			v1Raw as unknown as Partial<AppSettings>,
+			defaultAppSetting
+		);
+
+		expect(result.theme).toBe("dark");
+		expect(result.aiConfig.providers.gemini.apiKey).toBe("test-key");
+		expect(result.aiConfig.providers["openai-compatible"]).toBeDefined();
+		expect(result.voiceConfig.enabled).toBe(false);
+		expect(result.voiceConfig.activeProvider).toBe("openai");
+		expect(result.showCompleted).toBe(true);
+		expect(result.fontSize).toBe("base");
+	});
+
+	it("fresh install produces valid defaults", () => {
+		const result = migrateSettings({}, defaultAppSetting);
+		expect(result).toEqual(
+			expect.objectContaining({
+				theme: "system",
+				showCompleted: true,
+			})
+		);
+		expect(result.voiceConfig).toBeDefined();
+		expect(result.aiConfig.providers["openai-compatible"]).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

- **Fix stale settings model**: Replace flat `enableVoiceInput`/`voiceProvider` fields with structured `voiceConfig` object, add missing `"openai-compatible"` AI provider, and replace shallow `Object.assign()` merge with recursive deep merge so nested defaults (aiConfig, voiceConfig, filters, sort) apply correctly on upgrade
- **Secure API key storage**: Migrate plaintext API keys from `data.json` to Obsidian's `SecretStorage` (>= 1.11.4) with graceful fallback for older versions — keys are extracted on save, resolved on load, and migrated automatically on first upgrade
- **Add `_settingsVersion` tracking**: Enables one-time migration logic and future schema upgrades

## Files changed

| File | What |
|------|------|
| `src/settingsMigration.ts` | New — `deepMergeSettings()`, `migrateV1ToV2()`, `migrateSettings()` |
| `src/secretStorage.ts` | New — `hasSecretStorage()`, `resolveSecrets()`, `extractAndStoreSecrets()` |
| `src/settings.tsx` | Fix `DEFAULT_SETTINGS` to match v0.1.2 `AppSettings`, add secret extraction on save |
| `src/main.ts` | Wire migration pipeline, one-time secret migration on version upgrade |
| `src/settingsRepo.ts` | Intercept load/save for secret resolution/extraction |
| `tests/mocks/obsidian.ts` | Add `SecretStorage` mock class |
| `tests/unit/settingsMigration.test.ts` | 12 tests — deep merge, v1→v2 migration, idempotency |
| `tests/unit/secretStorage.test.ts` | 6 tests — extract/resolve round-trip, fallback, partial keys |

## Test plan

- [x] `pnpm lint` — no errors
- [x] `pnpm build` — successful production build
- [x] `pnpm test` — 79/79 tests pass (18 new)
- [ ] Manual: Open ExampleVault, verify settings load correctly, AI config preserved
- [ ] Manual: Set an API key, close/reopen plugin, verify key persists via SecretStorage (not in data.json)
- [ ] Manual: Test on Obsidian < 1.11.4 — keys stay in plaintext (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)